### PR TITLE
make buttons next to logo clickable in wide layout

### DIFF
--- a/frontend/app/styles/main.css
+++ b/frontend/app/styles/main.css
@@ -51,6 +51,10 @@ nav > .list-inline > li {
     margin-bottom: 10px;
 }
 
+.logo + div {
+    z-index: 1002;
+}
+
 .extra {
     margin-top: 1em;
 }


### PR DESCRIPTION
Right now the buttons next to the logo are under the "flash-alert" element, making them unclickable.

This fix makes them go on top of the message element.
