### PR TITLE
Fix selectedVersion reference bug

### DIFF
--- a/frontend/app/scripts/controllers/main.js
+++ b/frontend/app/scripts/controllers/main.js
@@ -87,7 +87,7 @@ angular.module('osscdnApp').controller('MainCtrl', function($scope, $http, $stat
                 };
             }).reverse();
 
-            library.selectedVersion = library.versions[0];
+            library.selectedVersion = angular.copy(library.versions[0]);
         });
     }
 


### PR DESCRIPTION
Setting library.selectedVersion = library.versions[0] creates an unwanted reference link that results in the [0] element getting overwritten once a new library.selectedVersion is selected. Using angular.copy prevents this unwanted reference.

![image](https://cloud.githubusercontent.com/assets/697848/3374450/667327dc-fbbe-11e3-96a1-0c1236e6980f.png)
